### PR TITLE
slight rewording

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@
       </p>
       <section>
         <h2>Identifier format</h2>
-        <p>Payment method identifiers are strings containing a <a>URL</a>. The string MUST be an <a>absolute URL</a>.</p>
+        <p>Payment method identifiers are <a>URLs</a>. The URL MUST be an <a>absolute URL</a>.</p>
       </section>
       <section>
         <h2>Identifier equivalence</h2>


### PR DESCRIPTION
the identifier string shouldn't "contain a URL" (which reads awkward and seems to allow that it can contain something else besides the URL), the identifier should actually _be a URL_, right?
