### PR TITLE
If URL parsing fails then always fail to match URLs.

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,15 +201,17 @@
           parsing <em>A</em> with no <a>base URL</a>.
           </li>
           <li>If the <a>URL parser</a> throws or if either <em>urlA.query</em>
-          or <em>urlA.fragment</em> are not <em>null</em> terminate the algorithm
-          with a result of <em>no match</em> and discard <em>A</em> from further matching.
+          or <em>urlA.fragment</em> are not <em>null</em> terminate the
+          algorithm with a result of <em>no match</em> and discard <em>A</em>
+          from further matching.
           </li>
           <li>Let <em>urlB</em> be the result from the <a>URL parser</a> when
           parsing <em>B</em> with no <a>base URL</a>.
           </li>
           <li>If the <a>URL parser</a> throws or if either <em>urlB.query</em>
-          or <em>urlB.fragment</em> are not <em>null</em> terminate the algorithm
-          with a result of <em>no match</em> and discard <em>B</em> from further matching.
+          or <em>urlB.fragment</em> are not <em>null</em> terminate the
+          algorithm with a result of <em>no match</em> and discard <em>B</em>
+          from further matching.
           </li>
           <li>The identifiers match if <em>urlA</em> <strong>equals</strong>
           <em>urlB</em> using the <a>URL equivalence</a> test (i.e. the test

--- a/index.html
+++ b/index.html
@@ -200,16 +200,16 @@
           <li>Let <em>urlA</em> be the result from the <a>URL parser</a> when
           parsing <em>A</em> with no <a>base URL</a>.
           </li>
-          <li>If either <em>urlA.query</em> or <em>urlA.fragment</em> are not
-          <em>null</em> terminate the algorithm with a result of <em>no
-          match</em> and discard <em>A</em> from further matching.
+          <li>If the <a>URL parser</a> throws or if either <em>urlA.query</em>
+          or <em>urlA.fragment</em> are not <em>null</em> terminate the algorithm
+          with a result of <em>no match</em> and discard <em>A</em> from further matching.
           </li>
           <li>Let <em>urlB</em> be the result from the <a>URL parser</a> when
           parsing <em>B</em> with no <a>base URL</a>.
           </li>
-          <li>If either <em>urlB.query</em> or <em>urlB.fragment</em> are not
-          <em>null</em> terminate the algorithm with a result of <em>no
-          match</em> and discard <em>B</em> from further matching.
+          <li>If the <a>URL parser</a> throws or if either <em>urlB.query</em>
+          or <em>urlB.fragment</em> are not <em>null</em> terminate the algorithm
+          with a result of <em>no match</em> and discard <em>B</em> from further matching.
           </li>
           <li>The identifiers match if <em>urlA</em> <strong>equals</strong>
           <em>urlB</em> using the <a>URL equivalence</a> test (i.e. the test


### PR DESCRIPTION
Fixes #27.
Fixes #8.