### PR TITLE
make fetching URL-PMI optional (closes #33)

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,23 +130,9 @@
           Fetching (dereferencing)
         </h2>
         <p>
-          As <a>URL-based payment method identifiers</a> serve primarily as
-          identifiers (and not a linked resource), it is OPTIONAL for user
-          agents to <a data-cite="!WHATWG-FETCH#concept-fetch">fetch</a> a
-          <a>URL-based payment method identifier</a>.
-        </p>
-        <p class="note">
-          The working group is in the early stages of standardizing a <a href=
-          "https://w3c.github.io/payment-method-manifest/">Payment
-          Manifest</a>, which will allow developers to describe their payment
-          methods in a machine-processable format. We encourage developers to
-          experiment with Payment Manifest by placing one at the <a>URL-based
-          payment method identifier</a>'s location, but caution that that
-          specification might change in incompatible ways during the
-          standardization process. If you'd like to follow along and
-          contribute, please subscribe to the <a href=
-          "https://github.com/w3c/payment-method-manifest/">payment-method-manifest
-          repository</a> on GitHub.
+          It is OPTIONAL for user agents to <a data-cite=
+          "!WHATWG-FETCH#concept-fetch">fetch</a> a <a>URL-based payment method
+          identifier</a>.
         </p>
       </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -125,6 +125,30 @@
           "!URL#concept-url-equals">equals</a>. [[!URL]]
         </p>
       </section>
+      <section>
+        <h2>
+          Fetching (dereferencing)
+        </h2>
+        <p>
+          As <a>URL-based payment method identifiers</a> serve primarily as
+          identifiers (and not a linked resource), it is OPTIONAL for user
+          agents to <a data-cite="!WHATWG-FETCH#concept-fetch">fetch</a> a
+          <a>URL-based payment method identifier</a>.
+        </p>
+        <p class="note">
+          The working group is in the early stages of standardizing a <a href=
+          "https://w3c.github.io/payment-method-manifest/">Payment
+          Manifest</a>, which will allow developers to describe their payment
+          methods in a machine-processable format. We encourage developers to
+          experiment with Payment Manifest by placing one at the <a>URL-based
+          payment method identifier</a>'s location, but caution that that
+          specification might change in incompatible ways during the
+          standardization process. If you'd like to follow along and
+          contribute, please subscribe to the <a href=
+          "https://github.com/w3c/payment-method-manifest/">payment-method-manifest
+          repository</a> on GitHub.
+        </p>
+      </section>
     </section>
     <section>
       <h2>

--- a/index.html
+++ b/index.html
@@ -87,8 +87,8 @@
         <p>
           Developers wanting to use a URL-based payment method identifier for a
           third party payment handler are encouraged to read the <a href=
-          "https://w3c.github.io/webpayments/proposals/method-practice/">Payment
-          Method Best Practice</a> document.
+          "https://github.com/w3c/payment-request-info/wiki/PaymentMethodPractice">
+          Payment Method Best Practice</a> document.
         </p>
       </div>
       <section>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/payment-method-id/dereferencing.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/payment-method-id/253f9e2...62ef24b.html)