### PR TITLE
Updated the link to the test-suit

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
       }],
       crEnd: "2017-10-31",
       github: "https://github.com/w3c/payment-method-id",
-      implementationReportURI: "https://w3c.github.io/test-results/payment-method-id/all.html",
+      implementationReportURI: "https://w3c.github.io/test-results/payment-request/all.html",
       license: "w3c-software-doc",
       previousMaturity: "FPWD",
       previousPublishDate: "2016-04-21",

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
       specStatus: "ED",
       // We can only indirectly test conformance, so we rely on certain tests
       // in the Payment Request API.
-      testSuiteURI: "https://w3c-test.org/payment-request/",
+      testSuiteURI: "https://w3c-test.org/payment-method-id/",
       wg: "Web Payments Working Group",
       wgPatentURI: "https://www.w3.org/2004/01/pp-impl/83744/status",
       wgURI: "https://www.w3.org/Payments/WG/",

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
       }],
       crEnd: "2017-10-31",
       github: "https://github.com/w3c/payment-method-id",
-      implementationReportURI: "https://w3c.github.io/payment-method-id/reports/implementation.html",
+      implementationReportURI: "https://w3c.github.io/test-results/payment-method-id/all.html",
       license: "w3c-software-doc",
       previousMaturity: "FPWD",
       previousPublishDate: "2016-04-21",

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
       }],
       crEnd: "2017-10-31",
       github: "https://github.com/w3c/payment-method-id",
-      implementationReportURI: "https://w3c.github.io/test-results/payment-request/all.html",
+      implementationReportURI: "https://w3c.github.io/test-results/payment-method-id/all.html",
       license: "w3c-software-doc",
       previousMaturity: "FPWD",
       previousPublishDate: "2016-04-21",


### PR DESCRIPTION
This PR updates the "test-suite" link at the top of the spec to point to the new test suite location. 

This is in context with #54


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yatri1609/payment-method-id/pull/55.html" title="Last updated on Sep 30, 2018, 4:58 AM GMT (fc31c71)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-method-id/55/14f2321...yatri1609:fc31c71.html" title="Last updated on Sep 30, 2018, 4:58 AM GMT (fc31c71)">Diff</a>