### PR TITLE
Editorial: Fixed duplication of url and spec name to sync with linked doc

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@
         <p>
           The steps to <dfn>validate a URL-based payment method
           identifier</dfn> are given by the following algorithm. The algorithm
-          takes a <a data-cite="!URL#concept-url">URL</a> <var>url</var> as
+          takes a <a data-cite="!URL#concept-url">URL</a> as
           input and returns true if the URL is valid:
         </p>
         <ol class="algorithm">
@@ -310,8 +310,8 @@
           "<code>basic-card</code>"
         </dt>
         <dd>
-          The <cite><a data-cite="payment-method-basic-card">Basic Card
-          Payment</a></cite> specification.
+          The <cite><a data-cite="payment-method-basic-card">Payment Method: Basic Card
+          </a></cite> specification.
         </dd>
       </dl>
     </section>

--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@
         <p>
           The steps to <dfn>validate a URL-based payment method
           identifier</dfn> are given by the following algorithm. The algorithm
-          takes a <a data-cite="!URL#concept-url">URL</a> as
+          takes a <a data-cite="!URL#concept-url">URL</a> <var>url</var> as
           input and returns true if the URL is valid:
         </p>
         <ol class="algorithm">


### PR DESCRIPTION
- Fixed duplication of url and spec name to sync with linked


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wonsuk73/payment-method-id/pull/57.html" title="Last updated on Oct 1, 2018, 10:33 PM GMT (1c63173)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/payment-method-id/57/646659e...wonsuk73:1c63173.html" title="Last updated on Oct 1, 2018, 10:33 PM GMT (1c63173)">Diff</a>